### PR TITLE
Verify github.io URLs with Trusted Publishing

### DIFF
--- a/tests/unit/forklift/test_legacy.py
+++ b/tests/unit/forklift/test_legacy.py
@@ -4793,84 +4793,6 @@ def test_missing_trailing_slash_redirect(pyramid_request):
 
 
 @pytest.mark.parametrize(
-    ("url", "publisher_url", "expected"),
-    [
-        (  # GitHub trivial case
-            "https://github.com/owner/project",
-            "https://github.com/owner/project",
-            True,
-        ),
-        (  # ActiveState trivial case
-            "https://platform.activestate.com/owner/project",
-            "https://platform.activestate.com/owner/project",
-            True,
-        ),
-        (  # GitLab trivial case
-            "https://gitlab.com/owner/project",
-            "https://gitlab.com/owner/project",
-            True,
-        ),
-        (  # URL is a sub-path of the TP URL
-            "https://github.com/owner/project/issues",
-            "https://github.com/owner/project",
-            True,
-        ),
-        (  # Normalization
-            "https://GiThUB.com/owner/project/",
-            "https://github.com/owner/project",
-            True,
-        ),
-        (  # TP URL is a prefix, but not a parent of the URL
-            "https://github.com/owner/project22",
-            "https://github.com/owner/project",
-            False,
-        ),
-        (  # URL is a parent of the TP URL
-            "https://github.com/owner",
-            "https://github.com/owner/project",
-            False,
-        ),
-        (  # Scheme component does not match
-            "http://github.com/owner/project",
-            "https://github.com/owner/project",
-            False,
-        ),
-        (  # Host component does not match
-            "https://gitlab.com/owner/project",
-            "https://github.com/owner/project",
-            False,
-        ),
-        (  # Host component matches, but contains user and port info
-            "https://user@github.com:443/owner/project",
-            "https://github.com/owner/project",
-            False,
-        ),
-        (  # URL path component is empty
-            "https://github.com",
-            "https://github.com/owner/project",
-            False,
-        ),
-        (  # TP URL path component is empty
-            # (currently no TPs have an empty path, so even if the given URL is a
-            # sub-path of the TP URL, we fail the verification)
-            "https://github.com/owner/project",
-            "https://github.com",
-            False,
-        ),
-        (  # Both path components are empty
-            # (currently no TPs have an empty path, so even if the given URL is the
-            # same as the TP URL, we fail the verification)
-            "https://github.com",
-            "https://github.com",
-            False,
-        ),
-    ],
-)
-def test_verify_url_with_trusted_publisher(url, publisher_url, expected):
-    assert legacy._verify_url_with_trusted_publisher(url, publisher_url) == expected
-
-
-@pytest.mark.parametrize(
     ("url", "project_name", "project_normalized_name", "expected"),
     [
         (  # PyPI /project/ case
@@ -4985,24 +4907,27 @@ def test_verify_url_pypi(url, project_name, project_normalized_name, expected):
 
 def test_verify_url():
     # `_verify_url` is just a helper function that calls `_verify_url_pypi` and
-    # `_verify_url_with_trusted_publisher`, where the actual verification logic lives.
+    # `OIDCPublisher.verify_url`, where the actual verification logic lives.
+    publisher_verifies = pretend.stub(verify_url=lambda url: True)
+    publisher_fails = pretend.stub(verify_url=lambda url: False)
+
     assert legacy._verify_url(
         url="https://pypi.org/project/myproject/",
-        publisher_url=None,
+        publisher=None,
         project_name="myproject",
         project_normalized_name="myproject",
     )
 
     assert legacy._verify_url(
         url="https://github.com/org/myproject/issues",
-        publisher_url="https://github.com/org/myproject",
+        publisher=publisher_verifies,
         project_name="myproject",
         project_normalized_name="myproject",
     )
 
     assert not legacy._verify_url(
         url="example.com",
-        publisher_url="https://github.com/or/myproject",
+        publisher=publisher_fails,
         project_name="myproject",
         project_normalized_name="myproject",
     )

--- a/tests/unit/oidc/models/test_github.py
+++ b/tests/unit/oidc/models/test_github.py
@@ -656,6 +656,26 @@ class TestGitHubPublisher:
             db_request.db.add(publisher2)
             db_request.db.commit()
 
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://repository_owner.github.io/repository_name/", True),
+            ("https://repository_owner.github.io/repository_name", True),
+            ("https://repository_owner.github.io/repository_name/subpage", True),
+            ("https://repository_owner.github.io/repository_name/../malicious", False),
+            ("https://repository_owner.github.io/", False),
+        ],
+    )
+    def test_github_publisher_verify_url(self, url, expected):
+        publisher = github.GitHubPublisher(
+            repository_name="repository_name",
+            repository_owner="repository_owner",
+            repository_owner_id="666",
+            workflow_filename="workflow_filename.yml",
+            environment="",
+        )
+        assert publisher.verify_url(url) == expected
+
 
 class TestPendingGitHubPublisher:
     def test_reify_does_not_exist_yet(self, db_request):

--- a/warehouse/oidc/models/_core.py
+++ b/warehouse/oidc/models/_core.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Unpack
 
+import rfc3986
 import sentry_sdk
 
 from sigstore.verify.policy import VerificationPolicy
@@ -324,6 +325,42 @@ class OIDCPublisherMixin:
         """
         # Only concrete subclasses are constructed.
         raise NotImplementedError
+
+    def verify_url(self, url: str) -> bool:
+        """
+        Verify a given URL against this Trusted Publisher's base URL
+
+        A URL is considered "verified" iff it matches the Trusted Publisher URL
+        such that, when both URLs are normalized:
+        - The scheme component is the same (e.g: both use `https`)
+        - The authority component is the same (e.g.: `github.com`)
+        - The path component is the same, or a sub-path of the Trusted Publisher URL
+          (e.g.: `org/project` and `org/project/issues.html` will pass verification
+          against an `org/project` Trusted Publisher path component)
+        - The path component of the Trusted Publisher URL is not empty
+        Note: We compare the authority component instead of the host component because
+        the authority includes the host, and in practice neither URL should have user
+        nor port information.
+        """
+        publisher_uri = rfc3986.api.uri_reference(self.publisher_base_url).normalize()
+        user_uri = rfc3986.api.uri_reference(url).normalize()
+        if publisher_uri.path is None:
+            # Currently no Trusted Publishers have an empty path component,
+            # so we defensively fail verification.
+            return False
+        elif user_uri.path and publisher_uri.path:
+            is_subpath = (
+                publisher_uri.path == user_uri.path
+                or user_uri.path.startswith(publisher_uri.path + "/")
+            )
+        else:
+            is_subpath = publisher_uri.path == user_uri.path
+
+        return (
+            publisher_uri.scheme == user_uri.scheme
+            and publisher_uri.authority == user_uri.authority
+            and is_subpath
+        )
 
 
 class OIDCPublisher(OIDCPublisherMixin, db.Model):


### PR DESCRIPTION
@woodruffw I'm opening this refactor PR on this repo, until the parent branch is merged (PR for that here: https://github.com/pypi/warehouse/pull/16485)

As we discussed on https://github.com/pypi/warehouse/pull/16485#discussion_r1718417410, this moves the logic for verifying URLs against a Trusted Publisher to `OIDCPublisherMixin.verify_url()`. It also specializes that function on `GithubPublisher` to also allow `github.io` documentation URLs.


<img width="247" alt="image" src="https://github.com/user-attachments/assets/1a80aa3e-61ac-465a-ad1c-0c19b0cc41c3">


