### PR TITLE
Dm/interface registration test

### DIFF
--- a/docs/dev/Makefile
+++ b/docs/dev/Makefile
@@ -178,4 +178,4 @@ pseudoxml:
 
 # https://github.com/sphinx-doc/sphinx-autobuild#using-with-makefile
 livehtml:
-	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	sphinx-autobuild --host 0.0.0.0 "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -576,3 +576,37 @@ def test_root_factory_access_control_list():
             ),
         ),
     ]
+
+
+def test_interfaces_registration(app_config):
+    import inspect
+    import sys
+
+    from zope.interface.interface import InterfaceClass
+
+    interfaces = set()
+    for module, obj in sys.modules.items():
+        if not module.startswith("warehouse") or not module.endswith(".interfaces"):
+            continue
+
+        for name, cls in inspect.getmembers(obj):
+            if (
+                name.startswith("I")
+                and name != "Interface"
+                and isinstance(cls, InterfaceClass)
+            ):
+                interfaces.add(cls)
+
+    # Remove generic interfaces used as bases (e.g. IGenericBillingService)
+    bases = {base for interface in interfaces for base in interface.getBases()}
+    interfaces -= bases
+
+    registered_interfaces = set()
+    for event in app_config.registry.introspector.get_category("pyramid_services"):
+        introspectable = event.get("introspectable")
+        interface = introspectable.discriminator[1][0]
+        registered_interfaces.add(interface)
+
+    difference = interfaces - registered_interfaces
+    # All interfaces must be registered but not all registrations are interfaces
+    assert not difference


### PR DESCRIPTION
This PR opens some discussions on wherever we want to try to detect if interfaces are registered in the tests.

On the pro side, it would have caught a problem like https://github.com/pypi/warehouse/pull/16302 .

On the other side: 
- I think the current implementation is brittle
- @woodruffw raised a concern about some features being gated (e.g. Beta) and purposefully not registered

The current test is failing because `IOriginCache` is not registered.
Indeed, the registration is under a flag : 

```python
def includeme(config):
    if "origin_cache.backend" in config.registry.settings:
        cache_class = config.maybe_dotted(
            config.registry.settings["origin_cache.backend"]
        )
        config.register_service_factory(cache_class.create_service, IOriginCache)
        config.add_view_deriver(html_cache_deriver)

    config.add_directive("register_origin_cache_keys", register_origin_cache_keys)
```
[source](https://github.com/pypi/warehouse/blob/1ea7c6f26bf669b5f5a4d6fb58982888bab28afb/warehouse/cache/origin/__init__.py#L149-L157)

This is not a problem because most of the calls to the `find_service` method are called in a try/catch block: 

```python
    try:
        cacher_factory = config.find_service_factory(IOriginCache)
    except LookupError:
        return
```
[source](https://github.com/pypi/warehouse/blob/1ea7c6f26bf669b5f5a4d6fb58982888bab28afb/warehouse/cache/origin/__init__.py#L49-L52)


However, this is not always the case : 
- [`purge_key`](https://github.com/pypi/warehouse/blob/5c666c72d7caae993b23b60c440970df05a2263e/warehouse/cache/origin/fastly.py#L32)
